### PR TITLE
Mention sunnahfast tracker sync in the Academy account panel

### DIFF
--- a/js/academy-auth.js
+++ b/js/academy-auth.js
@@ -1306,9 +1306,10 @@
       var acctBox = mk('div', { class: 'acad-lab-panel' });
       acctBox.appendChild(mk('div', { class: 'acad-lab-panel-title' }, 'Account'));
       acctBox.appendChild(mk('p', { class: 'acad-lab-note' },
-        'Your Academy account is the same account as lab.integrauth.com. Changing your email, ' +
-        'managing passkeys or two-factor, and deleting your account are all done there — deleting ' +
-        'it removes your Academy progress, exam attempts and certificates too.'));
+        'Your Academy account is the same account as lab.integrauth.com — and, if you sign in there ' +
+        'too, sunnahfast.integrauth.com\'s tracker sync. Changing your email, managing passkeys or ' +
+        'two-factor, and deleting your account are all done there — deleting it removes your Academy ' +
+        'progress, exam attempts and certificates, and any synced sunnahfast trackers, too.'));
       acctBox.appendChild(mk('div', { class: 'acad-lab-row' }, [
         mk('a', {
           class: 'acad-lab-btn', href: LAB_ORIGIN + '/account',


### PR DESCRIPTION
## Summary
- The account box already links out to lab.integrauth.com as the single canonical owner of the shared account; sunnahfast.integrauth.com now also signs in against that same account (optional login for cross-device tracker sync), so the copy names it alongside the Academy.
- Wording-only change, one paragraph in `js/academy-auth.js`. No functional/auth code changes.

## Test plan
- [x] `node --check js/academy-auth.js` — valid syntax
- [ ] Post-merge: visual check of the Academy account panel copy

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTgCWhAJWN5sdPGH2CKxbK)_