### PR TITLE
Verify legacy certificate serials, and keep the IP-retention promise

### DIFF
--- a/.assetsignore
+++ b/.assetsignore
@@ -36,6 +36,7 @@
 # --- build/dev tooling, not part of the site ---
 node_modules
 src
+tests
 tsconfig.json
 package*.json
 wrangler.toml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,6 +92,14 @@ jobs:
       - run: npm ci
       - run: npm run worker:typecheck
 
+      # `node --test` with type-stripping — no test framework and no extra dependency, but it does
+      # need the Node 22 pinned above. Covers the certificate-serial path on both sides: the server
+      # lookup, and the client functions extracted from the shipped verify.html. Wired in here
+      # because a test nothing runs is documentation, and this particular defect's whole failure mode
+      # is being invisible to us — a wrong verdict on /verify is only ever seen by a third party who
+      # never tells us. It gates the deploy for the same reason.
+      - run: npm test
+
       # A raw control byte in a source file makes that file BINARY to grep and ripgrep, which then
       # skip it silently. That is not a theoretical tidiness concern: oidc-rp.ts once shipped with a
       # literal NUL, US and DEL inside the character class of `safeReturnPath`'s open-redirect guard

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build": "npm run build:css && npm run build:js && npm run build:html",
     "worker:dev": "wrangler dev --persist-to ../.wrangler-state",
     "worker:deploy": "wrangler deploy",
-    "worker:typecheck": "tsc --noEmit"
+    "worker:typecheck": "tsc --noEmit",
+    "test": "node --test --experimental-strip-types \"tests/*.test.mjs\""
   },
   "keywords": [
     "IAM",

--- a/src/lib/server/api.ts
+++ b/src/lib/server/api.ts
@@ -67,7 +67,7 @@ import {
   signCertificateJwt,
   getPublicJwks,
   generateCertificateSerial,
-  normalizeCertificateSerial,
+  certificateSerialLookupCandidates,
 } from './certs';
 import { EXAM_QUESTION_COUNT, gradeExam, isKnownQuestion, type SubmittedAnswer } from './exam';
 import { clientIpFromHeader, hashClientIp } from './ip';
@@ -237,6 +237,28 @@ function normalizeName(value: string): string {
 /** ISO timestamp marking the start of the abuse-counting window ending now. */
 function abuseWindowStartIso(): string {
   return new Date(Date.now() - ABUSE_WINDOW_MS).toISOString();
+}
+
+/**
+ * Erase exam `ip_hash` values that have aged out of the counting window — the scheduled half.
+ *
+ * WHY IT IS SCHEDULED AS WELL AS ON THE WRITE PATH (audit finding R22-W-02). The submission
+ * handler below already scrubs on every attempt, and that is the cheap, common case. But it is
+ * driven ENTIRELY by a subsequent submission, and the exam is the only sign-in-gated action on
+ * this site: a quiet week leaves the last attempts' hashes in place indefinitely, and the very
+ * last attempt before traffic stops is never scrubbed at all, because nothing runs after it.
+ *
+ * `privacy.html` tells people "we erase that hash 24 hours later". That is a published
+ * commitment, not an implementation note, so it cannot be left conditional on traffic. The cron
+ * in `wrangler.toml` runs this hourly, which makes the erasure happen within an hour of the
+ * 24-hour mark whether or not anyone sits the exam.
+ *
+ * It reuses `abuseWindowStartIso()` deliberately: the scrub MUST use the same window start the
+ * counts use — see the note on `scrubExamAttemptIpHashesBefore` — so a later boundary can never
+ * erase keys that are still being counted.
+ */
+export async function sweepExpiredExamIpHashes(db: D1Database): Promise<void> {
+  await scrubExamAttemptIpHashesBefore(db, abuseWindowStartIso());
 }
 
 /**
@@ -1086,16 +1108,19 @@ export function createApp() {
   // cheerful `{valid:false}` — that is the bug this contract exists to prevent.
   // Callers must branch on `response.ok` FIRST and only then read `valid`.
   app.get('/certificates/verify/:serial', async (c) => {
-    // Canonicalise what the human typed (case, hyphens, spaces, 0/O and 1/I/L
-    // confusions) before comparing against the stored canonical form. Input that
-    // can't be one of our serials is answered as an authoritative "no such
-    // certificate" without touching the database.
-    const serial = normalizeCertificateSerial(c.req.param('serial'));
-    if (!serial) {
-      return c.json({ valid: false });
+    // Try what the human typed VERBATIM, then the canonicalised form (case, hyphens,
+    // spaces, 0/O and 1/I/L confusions). Both arms are needed: a certificate minted
+    // before the `IA-…` format keeps its original serial forever — it is the `jti`
+    // inside an already-signed JWT — and canonicalising is exactly what makes such a
+    // serial unfindable. See certificateSerialLookupCandidates for the full reasoning.
+    // Input that can be no format we have ever minted yields no candidates and is
+    // answered as an authoritative "no such certificate" without touching the database.
+    const candidates = certificateSerialLookupCandidates(c.req.param('serial'));
+    let row = null;
+    for (const candidate of candidates) {
+      row = await getCertificateBySerial(c.env.DB, candidate);
+      if (row) break;
     }
-
-    const row = await getCertificateBySerial(c.env.DB, serial);
     if (!row) {
       // Same 200 shape whether found or not — simplest for the frontend, and for a
       // public credential-verification endpoint the existence-leak concern is minor
@@ -1114,11 +1139,15 @@ export function createApp() {
 
   // Explicit "download the signed artifact" affordance: session-gated, owner-checked.
   app.get('/certificates/:serial/jwt', requireSession, async (c) => {
-    const serial = normalizeCertificateSerial(c.req.param('serial'));
-    if (!serial) {
-      return c.json({ error: 'not_found' }, 404);
+    // Same two-arm lookup as the public verifier above, and for the same reason: the
+    // holder of a legacy-serial certificate must still be able to download their own
+    // signed artifact. The owner check below is unchanged and still decides access.
+    const candidates = certificateSerialLookupCandidates(c.req.param('serial'));
+    let row = null;
+    for (const candidate of candidates) {
+      row = await getCertificateBySerial(c.env.DB, candidate);
+      if (row) break;
     }
-    const row = await getCertificateBySerial(c.env.DB, serial);
     if (!row || row.user_id !== c.get('userId')) {
       return c.json({ error: 'not_found' }, 404);
     }

--- a/src/lib/server/certs.ts
+++ b/src/lib/server/certs.ts
@@ -279,3 +279,58 @@ export function normalizeCertificateSerial(input: string): string | null {
   }
   return `${SERIAL_PREFIX}-${groups.join('-')}`;
 }
+
+/**
+ * Characters a stored serial can possibly contain, in ANY format this table has ever
+ * held: `IA-XXXX-XXXX-XXXX`, a 36-character `randomUUID`, and the nanoid-style
+ * `genId()` output that migration `0050_academy_certificates.sql` describes. Anything
+ * outside this set is junk and is never worth a D1 round trip.
+ */
+const OPAQUE_SERIAL_CHARS = /^[A-Za-z0-9_-]+$/;
+
+/** Shortest input worth a lookup at all — below this it cannot be any minted format. */
+const SERIAL_MIN_INPUT_LEN = 8;
+
+/**
+ * What to try looking up, in order, for a caller-supplied certificate id — at most two,
+ * deduplicated, empty when the input cannot be one of ours.
+ *
+ * WHY THIS EXISTS. `normalizeCertificateSerial` alone answers an authoritative
+ * `{valid:false}` for anything that is not `IA` + 12 Crockford characters. That is
+ * correct for junk and WRONG for a real certificate minted before this format: those
+ * keep their original serial forever, because the serial is the `jti` inside an
+ * already-signed JWT and rewriting it would invalidate the signature. The docstring on
+ * `generateCertificateSerial` above names the predecessor (a 36-character `randomUUID`)
+ * in its own aside, and the Lab's migration `0050` describes the column as `genId()`
+ * output — neither survives normalisation, so before this function existed every such
+ * holder was told, authoritatively, that their real credential was not in our records.
+ *
+ * The sister repo hit this exact defect on its own verifier and fixed it the same way
+ * (`integrauth/lab`, `src/lib/server/certificates.ts` → `serialLookupCandidates`): the
+ * RAW string first, because legacy serials are case-sensitive and must match byte for
+ * byte, and only then the canonicalised form, which is what rescues a lowercased or
+ * mis-hyphenated `IA-…` typed off a screenshot.
+ *
+ * This does NOT weaken the enumeration-oracle property that
+ * `generateCertificateSerial` reasons about: every legacy format has strictly MORE
+ * entropy than the 60 bits of the current one, so the raw arm cannot be guessed sooner
+ * than the canonical one can.
+ */
+export function certificateSerialLookupCandidates(input: string): string[] {
+  if (typeof input !== 'string') return [];
+  const trimmed = input.trim();
+  if (
+    trimmed.length < SERIAL_MIN_INPUT_LEN ||
+    trimmed.length > SERIAL_MAX_INPUT_LEN ||
+    !OPAQUE_SERIAL_CHARS.test(trimmed)
+  ) {
+    // Still allow a canonical `IA-…` through: it contains only safe characters anyway,
+    // but a caller may have sent it with spaces, which the charset test above rejects.
+    const canonicalOnly = normalizeCertificateSerial(input);
+    return canonicalOnly ? [canonicalOnly] : [];
+  }
+  const canonical = normalizeCertificateSerial(trimmed);
+  const out = [trimmed];
+  if (canonical && canonical !== trimmed) out.push(canonical);
+  return out;
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -10,7 +10,7 @@
 // the asset server instead and never reaches this code at all, which fails as a 404 rather than as
 // anything that would draw attention.
 
-import { createApp } from './lib/server/api';
+import { createApp, sweepExpiredExamIpHashes } from './lib/server/api';
 import { createAuthApp } from './lib/server/auth';
 import { withSecurityHeaders } from './lib/server/security';
 import type { Env } from './lib/server/env';
@@ -40,6 +40,25 @@ export default {
         false
       );
     }
+  },
+
+  /**
+   * Cron handler — `[triggers] crons` in wrangler.toml (audit finding R22-W-02).
+   *
+   * One job only: erase exam `ip_hash` values past their 24-hour retention window, which
+   * `privacy.html` promises unconditionally but which was previously driven only by a subsequent
+   * exam submission. See `sweepExpiredExamIpHashes` for the full reasoning.
+   *
+   * A throw here is logged and swallowed: a failed housekeeping run must not mark the scheduled
+   * event as failed and it is retried on the next tick an hour later, but a silent failure with
+   * nothing in `wrangler tail` would leave a broken privacy commitment looking healthy.
+   */
+  async scheduled(_event: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
+    ctx.waitUntil(
+      sweepExpiredExamIpHashes(env.DB).catch((error) => {
+        console.error('scheduled exam ip_hash sweep failed:', error);
+      })
+    );
   },
 } satisfies ExportedHandler<Env>;
 

--- a/tests/certificate-serial.test.mjs
+++ b/tests/certificate-serial.test.mjs
@@ -1,0 +1,133 @@
+/**
+ * Certificate-serial lookup — the server arm and the client box that feeds it.
+ *
+ * WHY THIS IS THE REPO'S FIRST TEST. `/verify` is the one page here whose failure mode is
+ * invisible to us: it renders a verdict to a third party — an employer checking a credential —
+ * who never tells us it was wrong. An audit of this repo (2026-08, `integrauth/lab`
+ * `docs/audit/gauntlet/R22-website-rp.md`, finding R22-W-03) found that a certificate minted
+ * before the `IA-XXXX-XXXX-XXXX` format could not be verified by ANY code path:
+ *
+ *   - the server reached `getCertificateBySerial` only through `normalizeCertificateSerial`,
+ *     which returns null for anything that is not `IA` + 12 Crockford characters, and that null
+ *     was answered as an authoritative `{valid:false}`;
+ *   - and the input box on `verify.html` had already destroyed such a serial before submit —
+ *     it uppercased and re-cut everything into groups of four, so a case-sensitive nanoid and a
+ *     36-character randomUUID both left the box mangled and were then rejected locally, without
+ *     a request ever being sent.
+ *
+ * Legacy serials cannot be migrated away: the serial is the `jti` inside an already-signed JWT,
+ * so rewriting it would invalidate the signature. Both halves are therefore permanent
+ * requirements, and this file pins both.
+ *
+ * No test framework and no new dependency: `node --test` with type-stripping, so the server
+ * function under test is imported from its real `.ts` source and the client functions are
+ * extracted from the real `verify.html` rather than retyped here (a retyped copy would keep
+ * passing after the page regressed, which is the failure this whole file exists to prevent).
+ *
+ * Run with `npm test`.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { certificateSerialLookupCandidates } from '../src/lib/server/certs.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const VERIFY_HTML = resolve(HERE, '../verify.html');
+
+/** The documented predecessor format (see generateCertificateSerial's docstring). */
+const UUID = '3f2a1b9c-4d5e-6f70-8192-a3b4c5d6e7f8';
+/** `genId()` output, per the Lab's migration 0050_academy_certificates.sql. */
+const NANOID = 'V1StGXR8_Z5jdHi6B-myT';
+const MODERN = 'IA-4KD7-9QX2-M3F8';
+
+test('server: a modern serial is looked up canonically, however it was typed', () => {
+  assert.deepEqual(certificateSerialLookupCandidates(MODERN), [MODERN]);
+  // Lowercased/mis-hyphenated off a screenshot: the raw attempt is harmless, the canonical
+  // one is what finds the row.
+  assert.deepEqual(certificateSerialLookupCandidates('ia-4kd7-9qx2-m3f8'), [
+    'ia-4kd7-9qx2-m3f8',
+    MODERN,
+  ]);
+  assert.deepEqual(certificateSerialLookupCandidates('IA4KD79QX2M3F8'), ['IA4KD79QX2M3F8', MODERN]);
+  // Crockford leniency: a typed O is the digit 0, a typed I/L is the digit 1.
+  assert.ok(certificateSerialLookupCandidates('IA-4KD7-9QX2-M3FO').includes('IA-4KD7-9QX2-M3F0'));
+});
+
+test('server: a LEGACY serial is looked up verbatim — the arm R22-W-03 was missing', () => {
+  // Exactly one candidate each, and it must be byte-identical: legacy serials are
+  // case-sensitive, so a canonicalising pass cannot be allowed anywhere near them.
+  assert.deepEqual(certificateSerialLookupCandidates(NANOID), [NANOID]);
+  assert.deepEqual(certificateSerialLookupCandidates(UUID), [UUID]);
+  assert.deepEqual(certificateSerialLookupCandidates(`  ${NANOID}  `), [NANOID]);
+});
+
+test('server: junk yields no candidates, so D1 is never touched for it', () => {
+  for (const junk of ['', '   ', 'short', 'hello world!!', "'; DROP TABLE", 'x'.repeat(200)]) {
+    assert.deepEqual(certificateSerialLookupCandidates(junk), [], `expected no lookup for ${junk}`);
+  }
+  // Not a string at all (a router can hand us undefined).
+  assert.deepEqual(certificateSerialLookupCandidates(undefined), []);
+});
+
+/**
+ * The client half. `formatSerialInput` and `normalizeSerial` are extracted from the shipped
+ * `verify.html` and executed, so this fails if the page's own copy regresses.
+ */
+function loadVerifyClient() {
+  const html = readFileSync(VERIFY_HTML, 'utf8');
+  const grab = (re, what) => {
+    const m = re.exec(html);
+    assert.ok(m, `could not extract ${what} from verify.html — the test cannot measure the page`);
+    return m[0];
+  };
+  const consts = grab(/var SERIAL_ALPHABET=[^\n]*?;/, 'the serial constants');
+  const normalize = grab(/function normalizeSerial\(input\)\{[\s\S]*?\n\}/, 'normalizeSerial');
+  const format = grab(/function formatSerialInput\(raw\)\{[\s\S]*?\n\}/, 'formatSerialInput');
+  const opaqueLine = grab(/if\(!serial&&\/\^[^\n]*?\)serial=typed;/, 'the legacy-opaque submit arm');
+  const opaqueSrc = /\/(\^[^/]+)\/\.test/.exec(opaqueLine)[1];
+
+  const scope = new Function(
+    `${consts}\n${normalize}\n${format}\n` +
+      `return {normalizeSerial, formatSerialInput, OPAQUE: new RegExp(${JSON.stringify(opaqueSrc)})};`,
+  )();
+
+  // Reproduces the submit handler's two lines, in order: canonicalise, else send verbatim.
+  scope.submitted = (typed) => {
+    const stripped = typed.replace(/\s+/g, '');
+    const canonical = scope.normalizeSerial(stripped);
+    if (canonical) return canonical;
+    return scope.OPAQUE.test(stripped) ? stripped : null; // null = rejected without a request
+  };
+  return scope;
+}
+
+test('client: the input box leaves a legacy serial exactly as typed', () => {
+  const { formatSerialInput } = loadVerifyClient();
+  // The regression that made R22-W-03 unfixable from the server alone: these came back
+  // uppercased and re-cut into groups of four.
+  assert.equal(formatSerialInput(UUID), UUID);
+  assert.equal(formatSerialInput(NANOID), NANOID);
+  assert.equal(formatSerialInput('IA20260101953f2a1b9c'), 'IA20260101953f2a1b9c');
+});
+
+test('client: the box still auto-formats a modern serial as it is typed', () => {
+  const { formatSerialInput } = loadVerifyClient();
+  assert.equal(formatSerialInput('IA4KD79QX2M3F8'), MODERN);
+  assert.equal(formatSerialInput('ia-4kd7-9qx2-m3f8'), MODERN);
+  assert.equal(formatSerialInput('ia4kd'), 'IA-4KD');
+  assert.equal(formatSerialInput(''), '');
+});
+
+test('client: a legacy serial is SENT, and only real junk is rejected locally', () => {
+  const { submitted } = loadVerifyClient();
+  assert.equal(submitted(UUID), UUID);
+  assert.equal(submitted(NANOID), NANOID);
+  assert.equal(submitted('ia-4kd7-9qx2-m3f8'), MODERN);
+  // Still rejected without a network call — the one message on that page that asserts
+  // something about the ID itself must stay reserved for input that can be no serial at all.
+  assert.equal(submitted('hello world!!'), null);
+  assert.equal(submitted('IA-4KD'), null);
+});

--- a/verify.html
+++ b/verify.html
@@ -31,13 +31,23 @@ return SERIAL_PREFIX+'-'+groups.join('-')
    certificate. Cursor position is preserved by counting alphanumerics (not raw chars) up
    to the caret, formatting, then walking that many alphanumerics back into the new string
    — a plain value reassignment would otherwise always snap the caret to the end.
-   Deliberately NOT capped at the current 14-character (IA + 12) serial length: an older,
-   longer certificate ID (IA-YYYYMMDD-<score>-<8 hex>, handled below) must survive typing
-   un-truncated so it can still be recognised and given its own explanation instead of a
-   generic invalid-format error — only the 64-char junk/DoS ceiling from the server's own
-   normalizeCertificateSerial() applies here. */
+   It engages ONLY while the box still holds a current-format serial in progress: alnum plus
+   dashes/spaces, starting with IA, no longer than IA + 12. Anything else is returned exactly
+   as typed, because uppercasing and re-grouping into fours is DESTRUCTIVE to the other
+   formats this box must accept. A certificate minted before `IA-XXXX-XXXX-XXXX` keeps its
+   original serial forever — the serial is the jti inside an already-signed JWT, so it cannot
+   be rewritten — and those legacy serials are case-SENSITIVE (a nanoid), or carry their own
+   grouping (a 36-character randomUUID's 8-4-4-4-12). Re-cutting them here made such a
+   certificate unverifiable no matter what the server did, which is the client half of the
+   same defect the two-arm lookup in certs.ts fixes. The older browser-generated
+   IA-YYYYMMDD-<score>-<8 hex> shape is likewise left as typed; the check below strips dashes
+   itself, so it is still recognised and still gets its own honest explanation. */
 function formatSerialInput(raw){
-var alnum=raw.toUpperCase().replace(/[^A-Z0-9]/g,'').slice(0,64);
+var compact=raw.replace(/[\s-]+/g,'');
+if(!/^[A-Za-z0-9]*$/.test(compact))return raw;
+if(compact.length>SERIAL_PREFIX.length+SERIAL_BODY_LEN)return raw;
+if(compact.length>=SERIAL_PREFIX.length&&compact.slice(0,SERIAL_PREFIX.length).toUpperCase()!==SERIAL_PREFIX)return raw;
+var alnum=compact.toUpperCase();
 var out='';
 for(var i=0;i<alnum.length;i++){if(i===SERIAL_PREFIX.length||(i>SERIAL_PREFIX.length&&(i-SERIAL_PREFIX.length)%SERIAL_GROUP_LEN===0))out+='-';out+=alnum[i]}
 return out
@@ -54,7 +64,11 @@ if(e.key==='Backspace'&&vid.selectionStart===vid.selectionEnd&&vid.selectionStar
 });
 vid.addEventListener('input',function(){
 var pos=vid.selectionStart==null?vid.value.length:vid.selectionStart,count=alnumCountBefore(vid.value,pos),next=formatSerialInput(vid.value);
-if(next!==vid.value)vid.value=next;
+/* Left as typed → touch nothing, caret included. The alnum-counting restore below is only
+   correct for a string this function just re-cut; applied to an untouched one it walks the
+   caret backwards over any dash the user typed themselves (a UUID's, for instance). */
+if(next===vid.value)return;
+vid.value=next;
 var newPos=posForAlnumCount(next,count);
 vid.setSelectionRange(newPos,newPos)
 });
@@ -73,6 +87,13 @@ if(!typed){warn('<strong>Enter a certificate ID.</strong> It is printed near the
    backtracking still finds the boundary correctly once dashes are out of the way. */
 if(/^IA\d{8}\d{1,3}[0-9A-Fa-f]{8}$/i.test(typed.replace(/-/g,''))){warn('<strong>This looks like an older certificate ID.</strong> Certificates issued before IntegrAuth Academy’s verifiable-certificate system launched used a different ID format and were generated in your browser, so they were never recorded here and can’t be looked up. Sign in at the <a href="/academy#acadExam" class="vfy-link">Academy</a> and re-take the final exam to get a new, permanently verifiable certificate.');return}
 var serial=normalizeSerial(typed);
+/* Not a current-format serial, but it could still be a REAL one: certificates minted before
+   this format keep their original serial (a nanoid, or a 36-character randomUUID) forever,
+   and normalizeSerial() rejects every one of them. Send it verbatim and let the server's
+   two-arm lookup decide — it tries the raw string first for exactly this case. Only input
+   that can be no format we have ever minted gets the local rejection below, which is
+   deliberately the one message on this page that asserts something about the ID itself. */
+if(!serial&&/^[A-Za-z0-9_-]{8,64}$/.test(typed))serial=typed;
 if(!serial){bad('<strong>That doesn’t look like a valid certificate ID.</strong> IDs look like <span class="vfy-serial">IA-4KD7-9QX2-M3F8</span> — check every character was copied from the certificate.');return}
 btn.disabled=true;out.hidden=true;
 fetch('/api/academy/certificates/verify/'+encodeURIComponent(serial),{credentials:'same-origin',headers:{'Accept':'application/json'}}).then(function(r){return r.text().then(function(t){var d=null;try{d=t?JSON.parse(t):null}catch(err){}return{ok:r.ok,status:r.status,data:d}})}).then(function(res){

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -90,6 +90,18 @@ binding = "DB"
 database_name = "lab-db"
 database_id = "9318da4d-88cc-4e0d-9b3d-7c46eff548e8"
 
+# Hourly housekeeping, one job: erase exam `ip_hash` values past their 24-hour retention window
+# (audit finding R22-W-02). privacy.html promises that erasure unconditionally, but the only thing
+# that used to perform it was the next exam submission — so on a quiet week the most recent hashes
+# outlived the promise, and the last attempt before traffic stopped was never scrubbed at all.
+# `scheduled` in src/worker.ts is the handler; it touches nothing else and no Lab-owned table.
+#
+# This is the only writer of a schedule here. If a deploy ever fails on this block, the CF_TOKEN is
+# missing the scope to manage cron triggers — fix the token, do not drop the trigger, or the site
+# goes back to publishing a retention commitment it does not keep.
+[triggers]
+crons = ["23 * * * *"]
+
 [vars]
 # Same Turnstile site key the Lab uses (committed there too — a Turnstile SITE key is the public
 # half of the widget, safe to commit; only TURNSTILE_SECRET is sensitive). Both apps share one


### PR DESCRIPTION
Two findings from the first audit of this repo (`integrauth/lab`, `docs/audit/gauntlet/R22-website-rp.md`), now fixable because push access was granted.

## R22-W-03 — no code path could verify a certificate whose serial predates `IA-XXXX-XXXX-XXXX`

Legacy serials cannot be migrated away: the serial is the `jti` inside an already-signed JWT, so rewriting it would invalidate the signature. **Both halves were broken**, and only the first was in the report:

- the server reached `getCertificateBySerial` only via `normalizeCertificateSerial`, whose `null` was answered as an authoritative `{valid:false}`;
- and `verify.html`'s input box had already destroyed such a serial before submit. Measured, by executing the page's own functions: a 36-character `randomUUID` came back as `3F-2A1B-9C4D-…` and a case-sensitive nanoid as `V1-STGX-R8Z5-…`, and both were then rejected locally with **no request ever sent**. A server-only fix would have gone green and helped nobody.

`certificateSerialLookupCandidates` now tries the raw string first (legacy serials are case-sensitive and must match byte for byte) and the canonical form second — mirroring the sister repo's fix for the same defect on its own verifier. The input box auto-formats only while its contents still look like a current-format serial; anything else is sent verbatim for the server to judge. The holder-only JWT download uses the same two arms, with its owner check unchanged.

No weakening of the enumeration property `generateCertificateSerial` reasons about: every legacy format has strictly more entropy than the current 60 bits.

The failure mode this fixes is invisible to us — a holder hands a printed ID to an employer, who is told authoritatively that it is not in IntegrAuth's records, and nobody ever reports it.

## R22-W-02 — the 24-hour exam IP-hash erasure had no timer

`privacy.html` promises it unconditionally; the only thing performing it was the next exam submission. On a quiet week the most recent hashes outlived the promise, and the last attempt before traffic stopped was never scrubbed at all. Adds an hourly cron and a `scheduled` handler doing that sweep and nothing else, against the same window start the counts use.

## First tests in this repo

`node --test` with type-stripping — no framework, no new dependency, and the CI job already pins Node 22. Six cases over both halves of the serial path, with the client functions **extracted from the shipped `verify.html`** rather than retyped (a retyped copy keeps passing after the page regresses). `tests` is added to `.assetsignore` in the same commit, since `[assets] directory = "."` publishes anything not listed there. Wired into the `check` job so it gates the deploy.

## Verification

- `npm run worker:typecheck` clean
- `npm test` 6/6
- `wrangler deploy --dry-run` clean, with `Ignoring asset: tests/…` confirmed
- Control run: the four modern-format serial cases measured **identical** before and after the change

## One thing to watch on deploy

The new `[triggers]` block means the deploy needs a `CF_TOKEN` that can manage cron triggers. If it cannot, the deploy step fails loudly — the fix is to widen the token, not to drop the trigger, and `wrangler.toml` says so at the block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mof1cnkMLYMatRoef2EEEc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mof1cnkMLYMatRoef2EEEc)_